### PR TITLE
Feature/smaller make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,9 @@
 # Usage: make host-build
 # requires vagrant and virtualbox, and the vagrant-scp plugin
 
-# targets are divided into host-* which run on the host machine,
-# and unprefixed targets that run on the build VM
-
-BUILDVM_RUNNING := $(shell vagrant status build | grep -c 'running (virtualbox)')
-NETROOTVM_RUNNING := $(shell vagrant status net-root | grep -c 'running (virtualbox)')
-DVM_RUNNING := $(shell vagrant status d | grep -c 'running (virtualbox)')
-FVM_RUNNING := $(shell vagrant status f | grep -c 'running (virtualbox)')
-
-ifeq ($(BUILDVM_RUNNING),1)
-host-power-build-vm: ;
-else
-host-power-build-vm:
-	vagrant up build
-endif
-
-ifeq ($(NETROOTVM_RUNNING),1)
-host-power-netroot-vm: ;
-else
-host-power-netroot-vm:
-	vagrant up net-root
-endif
-
-ifeq ($(DVM_RUNNING),1)
-host-power-d-vm: ;
-else
-host-power-d-vm: host-install
-	vagrant up d
-endif
-
-ifeq ($(FVM_RUNNING),1)
-host-power-f-vm: ;
-else
-host-power-f-vm: host-install
-	vagrant up f
-endif
-
 # scp source onto build box, do a build, then scp the result back to the host
-host-build: host-power-build-vm
+host-build:
+	vagrant up build
 	vagrant ssh build -c "sudo bash -c 'rm -rf /vagrant \
 	    && mkdir /vagrant \
 	    && chown vagrant:vagrant /vagrant'"
@@ -48,17 +13,16 @@ host-build: host-power-build-vm
 	vagrant scp build:/vagrant/.stack-work .stack-work
 
 host-clean:
-	vagrant destroy -f build
-	vagrant destroy -f net-root
-	vagrant destroy -f d
-	vagrant destroy -f f
+	vagrant destroy -f build net-root d f
 	rm -rf .stack-work .vagrant
 
 # install, but wherever user input would be needed instead use assumptions about the test network
-host-install: host-power-netroot-vm host-build
+host-install: 
+	vagrant up net-root build
 
 # perform full-stack testing with a variety of configurations
 # by taking control of all three vms in the test network
-host-test: host-install host-power-d-vm host-power-f-vm
+host-test: host-install
+	vagrant up d f 
 
 .PHONY: host-build host-clean host-install host-test


### PR DESCRIPTION
I took the liberty of reducing the makefile to the essentials; it wasn't easy to let the creative VM checks go.  `vagrant up` is idempotent, and costs mere seconds if the VM is already running, so I removed the checks against `vagrant status`.  Both `vagrant up` and `vagrant destroy` take multiple VM target names, so the code is simplified using that property where possible.

If I missed something intended from the dropped code, just go ahead and reject the PR.  I could have easily missed something.